### PR TITLE
SimEngineBF: fix engine registration

### DIFF
--- a/angr_platforms/bf/engine_bf.py
+++ b/angr_platforms/bf/engine_bf.py
@@ -174,7 +174,9 @@ class SimEngineBF(angr.SimEngine):
         """
         return True
 
+
 # Engine registration
-bf_engine_preset = angr.engines.vex_preset.copy()
-bf_engine_preset.add_default_plugin('default_engine', SimEngineBF)
-bf_engine_preset.set_order(['default_engine'])
+bf_engine_preset = angr.engines.basic_preset.copy()
+bf_engine_preset.add_default_plugin('bf', SimEngineBF)
+bf_engine_preset.default_engine = 'bf'
+bf_engine_preset.order = 'bf',

--- a/angr_platforms/ct64/ct64_angr.py
+++ b/angr_platforms/ct64/ct64_angr.py
@@ -55,6 +55,7 @@ class CT64KBlob(cle.backends.blob.Blob):
         self.memory.add_backer(mem_addr - self.linked_base, unistring)
         self._max_addr = max(len(unistring) + mem_addr, self._max_addr)
         self._min_addr = min(mem_addr, self._min_addr)
+        self.engine_preset = ct64k_engine_preset
 
 class SimCT64K(angr.SimOS):
     def __init__(self, project):
@@ -63,9 +64,6 @@ class SimCT64K(angr.SimOS):
             0x201: (hard_201_rd, hard_201_wr),
         }
         super(SimCT64K, self).__init__(project, 'ct64k')
-
-    def configure_project(self):
-        self.project.engines.register_plugin('default_engine', SimEngineCT64K())
 
     def state_blank(self, addr=None, **kwargs):
         if addr is None:

--- a/angr_platforms/ct64/ct64_angr.py
+++ b/angr_platforms/ct64/ct64_angr.py
@@ -65,6 +65,9 @@ class SimCT64K(angr.SimOS):
         }
         super(SimCT64K, self).__init__(project, 'ct64k')
 
+    def configure_project(self):
+        pass
+
     def state_blank(self, addr=None, **kwargs):
         if addr is None:
             addr = 0x1000

--- a/angr_platforms/ct64/ct64_engine.py
+++ b/angr_platforms/ct64/ct64_engine.py
@@ -261,3 +261,10 @@ def disasm(state, addr, length=None):
             break
         elif isinstance(b, Instruction2) and claripy.is_true(b.rm == 0):
             break
+
+
+# Engine registration
+ct64k_engine_preset = angr.engines.basic_preset.copy()
+ct64k_engine_preset.add_default_plugin('ct64k', SimEngineCT64K)
+ct64k_engine_preset.default_engine = 'ct64k'
+ct64k_engine_preset.order = 'ct64k',


### PR DESCRIPTION
See https://github.com/angr/angr/pull/897 for details.

I didn't manage to find why is the test_ct64.test_crackme failing, but I believe it doesn't have anything with the plugin refactor.