### PR TITLE
Fix MSP430 SUB instruction carry bit logic

### DIFF
--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -708,11 +708,11 @@ class Instruction_SUBC(Instruction_SUB):
         return dst - src - self.constant(1, src.ty) + self.get_carry()
 
     def carry(self, src, dst, ret):
-        src17 = src.cast_to(Type.int_17)
+        neg_src17 = (~src).cast_to(Type.int_17)
         dst17 = dst.cast_to(Type.int_17)
-        one17 = self.constant(1, Type.int_17)
         cr17 = self.get_carry().cast_to(Type.int_17)
-        return dst17 >= src17 + one17 - cr17
+        res17 = dst + neg_src17 + cr17
+        return res17[16]
 
 class Instruction_CMP(Instruction_SUB):
     opcode = '1001'

--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -708,14 +708,13 @@ class Instruction_SUBC(Instruction_SUB):
         return dst - src - self.constant(1, src.ty) + self.get_carry()
 
     def carry(self, src, dst, ret):
-        neg_src17 = (~src).cast_to(Type.int_17)
+        # Works for .w and .b mode
+        # Equivalent with checking the carry out of the MSB of dst + ~src + C
+        src17 = src.cast_to(Type.int_17)
         dst17 = dst.cast_to(Type.int_17)
+        one17 = self.constant(1, Type.int_17)
         cr17 = self.get_carry().cast_to(Type.int_17)
-        res17 = dst + neg_src17 + cr17
-        if self.data['b'] == '0':
-            return res17[16]
-        else:
-            return res17[8]
+        return dst17 >= src17 + one17 - cr17
 
 class Instruction_CMP(Instruction_SUB):
     opcode = '1001'

--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -731,7 +731,7 @@ class Instruction_SUB(Type3Instruction):
             return (ret[7] ^ src[7]) & (ret[7] ^ dst[7])
 
     def carry(self, src, dst, ret):
-        return dst > src
+        return dst >= src
 
 
 class Instruction_CMP(Instruction_SUB):

--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -651,12 +651,12 @@ class Instruction_ADD(Type3Instruction):
         if self.data['b'] == '0':
             src17 = src.cast_to(Type.int_17)
             dst17 = dst.cast_to(Type.int_17)
-            ret17 = self._compute_sum(src17, dst17)
+            ret17 = self.compute_result(src17, dst17)
             c = ret17[16]
         else:
             src9 = src.cast_to(Type.int_9)
             dst9 = dst.cast_to(Type.int_9)
-            ret9 = self._compute_sum(src9, dst9)
+            ret9 = self.compute_result(src9, dst9)
             c = ret9[8]
 
         return c

--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -33,8 +33,11 @@ def bits_to_signed_int(s):
     return Bits(bin=s).int
 
 class MSP430Instruction(Instruction):
-    commit_func = None
     opcode = None
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.commit_func = None
 
     # Default flag handling
     def zero(self, *args):
@@ -137,7 +140,7 @@ class MSP430Instruction(Instruction):
                  (o, OVERFLOW_BIT_IND, 'V'),
                  (c, CARRY_BIT_IND, 'C')]
         sreg = self.get_sr()
-        for flag, offset, _name in flags:
+        for flag, offset, _ in flags:
             if flag:
                 sreg = sreg & ~(1 << offset) | (flag.cast_to(Type.int_16) << offset).cast_to(sreg.ty)
         self.put_sr(sreg)

--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -712,7 +712,10 @@ class Instruction_SUBC(Instruction_SUB):
         dst17 = dst.cast_to(Type.int_17)
         cr17 = self.get_carry().cast_to(Type.int_17)
         res17 = dst + neg_src17 + cr17
-        return res17[16]
+        if self.data['b'] == '0':
+            return res17[16]
+        else:
+            return res17[8]
 
 class Instruction_CMP(Instruction_SUB):
     opcode = '1001'


### PR DESCRIPTION
When running angr alongside microcorruptions, I noticed the carry bit was not always set correctly on SUB, CMP and TST.

From wikipedia:

> While the carry flag is well-defined for addition, there are two ways in common use to use the carry flag for subtraction operations.

> The first uses the bit as a borrow flag, setting it if a<b when computing a−b, and a borrow must be performed. If a≥b, the bit is cleared. A subtract with borrow (SBB) instruction will compute a−b−C = a−(b+C), while a subtract without borrow (SUB) acts as if the borrow bit were clear. The 8080, Z80, 8051, x86[1] and 68k families (among others) use a borrow bit.

> The second takes advantage of the identity that −x = not(x)+1 and computes a−b as a+not(b)+1. The carry flag is set according to this addition, and subtract with carry computes a+not(b)+C, while subtract without carry acts as if the carry bit were set. **The result is that the carry bit is set if a≥b, and clear if a<b. The System/360,[2] 6502, MSP430, ARM and PowerPC processors use this convention.**

It seems the current carry check is not correct.