### PR TITLE
Fix overflow flag for MSP430 SUB(C) instruction

### DIFF
--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -706,11 +706,10 @@ class Instruction_SUBC(Type3Instruction):
         return src - dst + self.get_carry()
 
     def overflow(self, src, dst, ret):
-        # TODO: This is probably wrong
         if self.data['b'] == '0':
-            return (ret[15] ^ src[15]) & (ret[15] ^ dst[15])
+            return (ret[15] ^ dst[15]) & (src[15] ^ dst[15])
         else:
-            return (ret[7] ^ src[7]) & (ret[7] ^ dst[7])
+            return (ret[7] ^ dst[7]) & (src[7] ^ dst[7])
 
     def carry(self, src, dst, ret):
         return dst > (src + self.get_carry())
@@ -724,11 +723,10 @@ class Instruction_SUB(Type3Instruction):
         return dst - src
 
     def overflow(self, src, dst, ret):
-        # TODO: This is probably wrong
         if self.data['b'] == '0':
-            return (ret[15] ^ src[15]) & (ret[15] ^ dst[15])
+            return (ret[15] ^ dst[15]) & (src[15] ^ dst[15])
         else:
-            return (ret[7] ^ src[7]) & (ret[7] ^ dst[7])
+            return (ret[7] ^ dst[7]) & (src[7] ^ dst[7])
 
     def carry(self, src, dst, ret):
         return dst > src


### PR DESCRIPTION
From https://sites.google.com/site/arch1utep/home/course_outline/arithmetic_flags:

```
SUB(.B),SUBC(.B),CMP(.B) 
V=1 when the result of
    Positive – Negative is a  Negative 
    Negative – Positive is a Positive [...] 
V=0 othewise
```
So dst and res should not have the same sign and dst and src should also not have the same sign (i.e. src and ret should have the same sign.

From wikipedia:

> The overflow flag is thus set when **the most significant bit** (here considered the sign bit) **is changed** by adding two numbers with the same sign **(or subtracting two numbers with opposite signs)**. Overflow never occurs when the sign of two addition operands are different (or the sign of two subtraction operands are the same).