### PR TITLE
Install sub-modules with pip by using find_packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 setup(
     name='angr_platforms',
     version='0.1',
     description='A collection of extra platforms for angr',
-    packages=['angr_platforms'],
+    packages=find_packages(),
     install_requires=[
         'angr',
         'cle',


### PR DESCRIPTION
Sub-modules (e.g. msp430) are not found when angr-platforms is installed with pip, because only the top-level module is listed.
Using setuptools' find_packages function corrects this.

Fixes #30.