### PR TITLE
Corect flag setting for BIS instruction on MSP430.

### DIFF
--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -808,6 +808,14 @@ class Instruction_BIS(Type3Instruction):
     def compute_result(self, src, dst):
         return src | dst
 
+    def negative(self, src, dst, ret):
+        # pylint: disable=arguments-differ
+        pass
+
+    def zero(self, src, dst, ret):
+        # pylint: disable=arguments-differ
+        pass
+
 
 class Instruction_XOR(Type3Instruction):
     # Exclusive Or


### PR DESCRIPTION
The BIS instruction on MSP430 does not set any flags: see [page 6 of this reference](https://www.ti.com/sc/docs/products/micro/msp430/userguid/as_5.pdf). I did not see any other incorrect flag cases.

This PR prevents the BIS instruction setting any flag values when executed, using the same pattern as other instructions which do not set flags, e.g. the BIC instruction.