### PR TITLE
fix main for BF lifter

### DIFF
--- a/angr_platforms/bf/lift_bf.py
+++ b/angr_platforms/bf/lift_bf.py
@@ -130,7 +130,7 @@ class Instruction_DEC(Instruction):
 
 class BracketInstruction(Instruction):
     jump_table = {}
-    
+
     def calculate_jump(self, relevant_instructions):
         bracket_stack = [self]
         if self.addr in self.jump_table:
@@ -146,7 +146,7 @@ class BracketInstruction(Instruction):
                     return instr.addr + 1
         if len(bracket_stack) > 0:
             raise Exception('Missing matching %s for %s at address %d' % (self.closing.name, self.name, self.addr))
-            
+
 class Instruction_SKZ(BracketInstruction):
     bin_format = bin(ord("["))[2:].zfill(8)
     name = 'skz'
@@ -253,14 +253,12 @@ if __name__ == '__main__':
     logging.getLogger('pyvex').setLevel(logging.DEBUG)
     logging.basicConfig()
 
-    irsb_ = pyvex.IRSB(None, 0, arch=archinfo.arch_from_id('bf'))
     test1 = b'<>+-[].,'
     test2 = b'<>+-[].,'
-    lifter = LifterBF(irsb_, test1, len(test1) , len(test1), 0, None)
-    lifter.lift()
+    lifter = LifterBF(arch=archinfo.arch_from_id('bf'), addr=0)
+    lifter._lift(data=test1)
     lifter.irsb.pp()
 
-    irsb_ = pyvex.IRSB(None, 0, arch=ArchBF())
-    lifter = LifterBF(irsb_, test2, len(test2),len(test2),0,  None)
-    lifter.lift()
+    lifter = LifterBF(arch=ArchBF(), addr=0)
+    lifter._lift(data=test2)
     lifter.irsb.pp()


### PR DESCRIPTION
the used API has changed in the latest version of angr.
Essentially the arguments passed to the lifter changed
and 'lift' has been replaced with '_lift'