### PR TITLE
fix python3 errors about relative imports

### DIFF
--- a/angr_platforms/bf/lift_bf.py
+++ b/angr_platforms/bf/lift_bf.py
@@ -2,13 +2,14 @@ import archinfo
 import pyvex
 from pyvex.lifting.util import *
 from pyvex.lifting import register
-from .arch_bf import ArchBF
 import bitstring
 import sys
 import os
 import claripy
 from angr import SimValueError
 import logging
+
+from arch_bf import ArchBF
 
 log = logging.getLogger("LifterBF")
 

--- a/angr_platforms/bf/simos_bf.py
+++ b/angr_platforms/bf/simos_bf.py
@@ -3,7 +3,8 @@ from angr.procedures import SIM_PROCEDURES as P, SIM_LIBRARIES as L
 from angr.procedures.definitions import SimSyscallLibrary
 from angr import SimProcedure
 from angr.calling_conventions import SimCC, register_syscall_cc, register_default_cc, SimCCUnknown, SimRegArg
-from .arch_bf import ArchBF
+
+from arch_bf import ArchBF
 
 
 class WriteByteAtPtr(SimProcedure):


### PR DESCRIPTION
running `lift_bf.py`'s `main` function will result in:

```
Traceback (most recent call last):
  File "lift_bf.py", line 12, in <module>
    from .arch_bf import ArchBF
ImportError: attempted relative import with no known parent package
```

when running it with python3.

To fix I removed the prefixed '.' and separated the import from the others to make it more obvious it's a local import