### PR TITLE
Fix various inaccuracies in the RISC-V lifter

### DIFF
--- a/angr_platforms/risc_v/instrs_riscv/i_instr.py
+++ b/angr_platforms/risc_v/instrs_riscv/i_instr.py
@@ -82,7 +82,8 @@ class Instruction_SRAI(I_Instruction):
         return data
 
     def compute_result(self, src1, _):
-        return (~((~src1) >> self.get_shift_amount())) & self.constant(0xffffffff, Type.int_32)
+        shftamnt = self.get_shift_amount()
+        return src1.sar(shftamnt).cast_to(Type.int_32)
 
 
 class Instruction_SLTI(I_Instruction):

--- a/angr_platforms/risc_v/instrs_riscv/i_instr.py
+++ b/angr_platforms/risc_v/instrs_riscv/i_instr.py
@@ -94,10 +94,7 @@ class Instruction_SLTI(I_Instruction):
 
     # TODO: ISA manual mentions sign extension, check if properly implemented
     def compute_result(self, src1, imm):
-        src1.is_signed = True
-        imm.is_signed = True
-        val = 1 if src1.signed < imm.signed else 0
-        return self.constant(val, Type.int_32)
+        return (src1.signed < imm.signed).ite(1, 0)
 
 
 class Instruction_SLTIU(I_Instruction):
@@ -106,10 +103,7 @@ class Instruction_SLTIU(I_Instruction):
     name = 'SLTIU'
 
     def compute_result(self, src1, imm):
-        src1.is_signed = False
-        imm.is_signed = False
-        val = 1 if src1 < imm else 0
-        return self.constant(val, Type.int_32)
+        return (src1 < imm).ite(1, 0)
 
 class Instruction_LB(I_Instruction):
     func3='000'

--- a/angr_platforms/risc_v/instrs_riscv/i_instr.py
+++ b/angr_platforms/risc_v/instrs_riscv/i_instr.py
@@ -118,7 +118,7 @@ class Instruction_LB(I_Instruction):
 
     def compute_result(self, src, imm):
         addr = src + imm.signed
-        value = self.load(addr, Type.int_8).cast_to(Type.int_32)
+        value = self.load(addr, Type.int_8).widen_signed(Type.int_32)
         return value.signed
 
 class Instruction_LH(I_Instruction):
@@ -128,7 +128,7 @@ class Instruction_LH(I_Instruction):
 
     def compute_result(self, src, imm):
         addr = src + imm
-        value = self.load(addr, Type.int_16).cast_to(Type.int_32)
+        value = self.load(addr, Type.int_16).widen_signed(Type.int_32)
         return value.signed
 
 class Instruction_LW(I_Instruction):
@@ -149,7 +149,7 @@ class Instruction_LBU(I_Instruction):
     def compute_result(self, src, imm):
         addr = src + imm.signed
 
-        return self.load(addr, Type.int_8).cast_to(Type.int_32)
+        return self.load(addr, Type.int_8).widen_unsigned(Type.int_32)
 
 class Instruction_LHU(I_Instruction):
     func3='101'
@@ -158,7 +158,7 @@ class Instruction_LHU(I_Instruction):
 
     def compute_result(self, src, imm):
         addr= src+imm.signed
-        return self.load(addr, Type.int_16).cast_to(Type.int_32)
+        return self.load(addr, Type.int_16).widen_unsigned(Type.int_32)
 
 
 class Instruction_JALR(I_Instruction):

--- a/angr_platforms/risc_v/instrs_riscv/instruction_patterns.py
+++ b/angr_platforms/risc_v/instrs_riscv/instruction_patterns.py
@@ -94,7 +94,7 @@ class I_Instruction(RISCV_Instruction):
         return self.constant(data, Type.int_32)
 
     def get_shift_amount(self):
-        num = BitArray(bin=self.data['I']).int
+        num = BitArray(bin=self.data['I']).uint
         return self.constant(num, Type.int_8)
 
     def get_optional_func7(self):

--- a/angr_platforms/risc_v/instrs_riscv/r_instr.py
+++ b/angr_platforms/risc_v/instrs_riscv/r_instr.py
@@ -94,10 +94,7 @@ class Instruction_SLT(R_Instruction):
     name='SLT'
 
     def compute_result(self, src1, src2):
-        src1.is_signed = True
-        src2.is_signed = True
-        val = 1 if src1 < src2 else 0
-        return self.constant(val, Type.int_32)
+        return (src1.signed < src2.signed).ite(1, 0)
 
 
 class Instruction_SLTU(R_Instruction):
@@ -107,10 +104,7 @@ class Instruction_SLTU(R_Instruction):
     name = 'SLTU'
 
     def compute_result(self, src1, src2):
-        src1.is_signed = False
-        src1.is_signed = False
-        val = 1 if src1 < src2 else 0
-        return self.constant(val, Type.int_32)
+        return (src1 < src2).ite(1, 0)
 
 
 class Instruction_MUL(R_Instruction):

--- a/angr_platforms/risc_v/instrs_riscv/r_instr.py
+++ b/angr_platforms/risc_v/instrs_riscv/r_instr.py
@@ -59,7 +59,7 @@ class Instruction_SLL(R_Instruction):
     name = 'SLL'
 
     def compute_result(self, src1, src2):
-        shftamnt = self.get(int(self.data['S'], 2), Type.int_8)
+        shftamnt = src2.narrow_low(Type.int_5).cast_to(Type.int_8)
         return (src1 << shftamnt) & self.constant(0xffffffff, Type.int_32)
 
 
@@ -70,7 +70,7 @@ class Instruction_SRL(R_Instruction):
     name = 'SRL'
 
     def compute_result(self, src1, src2):
-        shftamnt = self.get(int(self.data['S'], 2), Type.int_8)
+        shftamnt = src2.narrow_low(Type.int_5).cast_to(Type.int_8)
         return (src1 >> shftamnt) & self.constant(0xffffffff, Type.int_32)
 
 # Arithmetic shift is not easily mapped, so leaving this as an TODO
@@ -83,8 +83,8 @@ class Instruction_SRA(R_Instruction):
     name = 'SRA'
 
     def compute_result(self, src1, src2):
-        shftamnt = self.get(int(self.data['S'], 2), Type.int_8)
-        return (~((~src1) >> shftamnt)) & self.constant(0xffffffff, Type.int_32)
+        shftamnt = src2.narrow_low(Type.int_5).cast_to(Type.int_8)
+        return src1.sar(shftamnt).cast_to(Type.int_32)
 
 
 class Instruction_SLT(R_Instruction):


### PR DESCRIPTION
This patchset fixes several issues where the provided lifter for the RISC-V 32-bit base instruction set would not correctly capture the semantics of RISC-V instruction as mandated by the RISC-V specification. As illustrated in #62, this causes angr to miss execution paths during symbolic execution, when used with this lifter. With this patchset applied, angr finds all 625 paths in the example binary provided in #62.

Specifically, this patchset fixes the following issues:

1. R-Type shift instructions used the lower bits of the register index, not the register value as a shift amount. Additionally, arithmetic shift was modeled incorrectly.
2. Load instruction did not properly zero- and sign-extend the register value.
3. The shift value for I-type instructions was incorrectly extracted as a signed value.
4. The comparison instructions (SLT, SLTI, …) did not correctly compare signed integers.

With these patches applied, angr passes the [riscv-tests](https://github.com/riscv/riscv-tests) for the 32-bit base instruction set (rv32i). I did not test the lifter for additional instruction set extensions (e.g. the M- or C-extension).

Fixes #62 

---

CC: @twizmwazin