### PR TITLE
msp430: fix BR instruction behavior and register-indirect @Rn disassembly

### DIFF
--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -330,7 +330,7 @@ class MSP430Instruction(Instruction):
             reg_str = "%d(%s)" % (imm, reg_name)
         # Indirect mode; fetch address in register; store is a write there.
         elif reg_mode == ArchMSP430.Mode.INDIRECT_REGISTER_MODE:
-            reg_str = "@%s" % reg_str
+            reg_str = "@%s" % reg_name
         # Indirect Autoincrement mode. Increment the register by the type size, then access it
         elif reg_mode == ArchMSP430.Mode.INDIRECT_AUTOINCREMENT_MODE:
             reg_str = "@%s+" % reg_name

--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -648,7 +648,7 @@ class Instruction_MOV(Type3Instruction):
                 self.jump(None, newpc, jumpkind=JumpKind.Ret)
             else:
                 # If we're setting PC, but not from SP+, it's a BR instead
-                self.jump(None, self.constant(self.addr, REGISTER_TYPE))
+                self.jump(None, src)
         return src
 
     def negative(self, src, dst, ret):


### PR DESCRIPTION
 Current behavior erroneously jumps to the _address_ of the BR instruction, instead of the SRC operand. This leads to an infinite loop as per below.
    
    ========================
    EXAMPLE CODE (objdump)
    ========================
    
      7282:       30 40 68 73     br      #0x7368
    
    ========================
    ORIGINAL BEHAVIOR
    ========================
    
    *** STEP 0
    block of len 4 at ip 0x7282
    ---- BEGIN VEX ----
    IRSB {
    
       00 | ------ IMark(0x7282, 4, 0) ------
       01 | PUT(pc) = 0x7368
       NEXT: PUT(pc) = 0x7282; Ijk_Boring
    }
    ---- END VEX ----
    
    *** STEP 1
    block of len 4 at ip 0x7282
    ...
    
    ========================
    NEW BEHAVIOR
    ========================
    
    *** STEP 0
    block of len 4 at ip 0x7282
    ---- BEGIN VEX ----
    IRSB {
    
       00 | ------ IMark(0x7282, 4, 0) ------
       01 | PUT(pc) = 0x7368
       NEXT: PUT(pc) = 0x7368; Ijk_Boring
    }
    ---- END VEX ----
    
    ==== STEP 1
    block of len 48 at ip 0x7368
    ...

