### PR TITLE
Remove unused writeout argument

### DIFF
--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -507,7 +507,7 @@ class Instruction_RRA(Type1Instruction):
     opcode = "010"
     name = 'rra'
 
-    def compute_result(self, src, writeout):
+    def compute_result(self, src):
         # Do it
         src >>= 1
         # A shitty sign-extend


### PR DESCRIPTION
TypeError: compute_result() missing 1 required positional argument: 'writeout'
