### PR TITLE
Unify jmp and br behaviour

### DIFF
--- a/angr_platforms/msp430/instrs_msp430.py
+++ b/angr_platforms/msp430/instrs_msp430.py
@@ -658,7 +658,8 @@ class Instruction_MOV(Type3Instruction):
             else:
                 # If we're setting PC, but not from SP+, it's a BR instead
                 self.jump(None, src)
-        return src
+        else:
+            return src
 
     def negative(self, src, dst, ret):
         # pylint: disable=arguments-differ


### PR DESCRIPTION
Example
```
init_state.inspect.b('exit', when=angr.BP_BEFORE, action=check_jump)

def check_jump(state):
    addr = state.regs.ip
```

For jmp, jz, ... instructions 'addr' will contain the value of ip BEFORE THE JMP instruction as they only execute self.jump(...) (https://github.com/angr/angr-platforms/blob/master/angr_platforms/msp430/instrs_msp430.py#L933)

For a branch instruction https://github.com/angr/angr-platforms/blob/master/angr_platforms/msp430/instrs_msp430.py#L660-L661, a value (src) will be returned, which will trigger an immediate commit (https://github.com/angr/pyvex/blob/master/pyvex/lifting/util/instr_helper.py#L132-L134). 

In the example above, the br instruction will thus immediately commit the result to the ip, so the 'addr' will contain the ip AFTER THE BR instruction (so 'addr' will contain the ip after the br)